### PR TITLE
feat: require, dynamic import statements, decouple tree state from parser

### DIFF
--- a/extension/src/SaplingParser.ts
+++ b/extension/src/SaplingParser.ts
@@ -9,7 +9,7 @@ import {
     VariableDeclaration
 } from '@babel/types';
 
-import { ImportData, Token, Tree } from '../src/types';
+import { ImportData, Token, Tree } from './types';
 
 export class SaplingParser {
   /** Public method to generate component tree based on entry file or input node.

--- a/extension/src/webviews/service/Navigation.ts
+++ b/extension/src/webviews/service/Navigation.ts
@@ -2,7 +2,7 @@ import PubSub from 'pubsub-js';
 import { ACTIONS } from "../actions";
 import { PubSubEvents } from '../constants/PubSubEvents';
 import { renderProvider } from "../pages/sidebar";
-import { INode } from "../Tree";
+import { INode } from "../../types";
 
 export default class Navigation {
     static moveUp(node: INode) {

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -10,7 +10,7 @@
 		"jsx": "react",
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": false  /* enable all strict type-checking options */,
+		"strict": false /* enable all strict type-checking options */,
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
@@ -20,7 +20,6 @@
 		"node_modules",
 		".vscode-test",
 		"src/webviews",
-    "src/test/test_apps"
+		"src/test/test_apps"
 	]
 }
-


### PR DESCRIPTION
## Testing and bug fixes

- Updated import statement. 
- Mocha test issue fixed and now functional.

## TODO Notes

- Fix failing test cases.
```
2) It works for third party / React Router components and destructured imports
    - React router should be designated as third party and reactRouter:
    - Tippy should be designated as third party and not reactRouter:
3) It identifies a Redux store connection and designates the component as such
    - The redux properties of the connected component and the unconnected component should be true and false, respectively:
6) It works for badly imported children nodes
    - improperly imported child component should exist but show an error:
7) It should log an error when the parser encounters a javascript syntax error
    - Should have a nonempty error message on the invalid child and not parse further:
9) It should properly count repeat components and consolidate and grab their props
    - Grandchild should have a count of 2:
```